### PR TITLE
Update RequestExecutor.php

### DIFF
--- a/lib/TransactPRO/Gate/Request/RequestExecutor.php
+++ b/lib/TransactPRO/Gate/Request/RequestExecutor.php
@@ -37,10 +37,14 @@ class RequestExecutor implements RequestExecutorInterface
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_TIMEOUT, 30);
         curl_setopt($ch, CURLOPT_POST, 1);
+        
         if ($this->verifySSL) {
             curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
             curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 1);
+        } else {
+            curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
         }
+        
         curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($postData));
 
         $curlResult = curl_exec($ch);


### PR DESCRIPTION
working on local machine or stage server cURL throwing an error SSL verification error. If verifySSL variable set to false, better to set CURLOPT_SSL_VERIFYPEER false as well.