### PR TITLE
GFOP-237  Possibility to pass merchant_transaction_id in Sratus Request

### DIFF
--- a/lib/TransactPRO/Gate/Builders/StatusRequestDataBuilder.php
+++ b/lib/TransactPRO/Gate/Builders/StatusRequestDataBuilder.php
@@ -6,13 +6,24 @@ class StatusRequestDataBuilder extends Builder
 {
     public function build()
     {
-        return array(
-            'request_type'        => $this->getField('request_type', 'transaction_status'),
-            'init_transaction_id' => $this->getField('init_transaction_id'),
-            'f_extended'          => $this->getField('f_extended', '5')
+        $dataArray = array(
+            'request_type' => $this->getField('request_type', 'transaction_status'),
+            'f_extended'   => $this->getField('f_extended', '5')
         );
-    }
 
+        $initTransactionID = $this->getField('init_transaction_id');
+        if (!empty($initTransactionID)) {
+            $dataArray['init_transaction_id'] = $initTransactionID;
+        }
+
+        $merchantTransactionID = $this->getField('merchant_transaction_id');
+        if (!empty($merchantTransactionID)) {
+            $dataArray['merchant_transaction_id'] = $merchantTransactionID;
+        }
+        return $dataArray;
+    }
+    
+    
     protected function checkData()
     {
         $this->checkMandatoryField('init_transaction_id');


### PR DESCRIPTION
Mecahnt can replace “init_transaction_id” field with “merchant_transaction_id” field, and pass
corresponding transaction value. In this case, gateway will return status for transaction with
corresponding merchant transaction ID.