### PR TITLE
Fix composer package name and version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ You must adopt library for your projects by yourselves, I only provide basic fun
 # Installation
 ### Composer
 Recommended way of installation is through [composer](http://getcomposer.org/).  
-Run command line command `composer require transactpro/transactpro-integration-php` or add to your composer.json:
+Run command line command `composer require transact-pro/gate` or add to your composer.json:
 ```javascript
 "require": {
-    "transact-pro/gate": "v1.0.0"
+    "transact-pro/gate": "^v1.0"
 }
 ```
 And then install with:


### PR DESCRIPTION
There's no such composer package as stated in readme. 
Also, there's no reason to limit package version to v1.0.0, as greater versions (1.0.2) already exist, fururemore composer will insert ^v1.0 when using "composer require".